### PR TITLE
Fix film name input in main.cpp

### DIFF
--- a/GuessTheMovie/main.cpp
+++ b/GuessTheMovie/main.cpp
@@ -11,7 +11,7 @@ int main()
 
 
 	std::string film_name;
-	std::cin >> film_name;
+	std::getline(std::cin, film_name);
 
 
 


### PR DESCRIPTION
If film name contains whitespaces, only the first word is read